### PR TITLE
fix bug:

### DIFF
--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -6,7 +6,11 @@ import time
 import json
 import ast
 import cgi
-from StringIO import StringIO
+
+try:
+    from StringIO import StringIO # python 2
+except ImportError:
+    from io import StringIO # python 3
 
 from .messages import MESSAGE_TYPES, UnknownMessage
 from .exceptions import (

--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -925,7 +925,7 @@ class WechatBasic(object):
             **kwargs
         )
         r.raise_for_status()
-        response_json = ast.literal_eval(r.content)
+        response_json = r.json()
         headimgurl = response_json.get('headimgurl')
         if headimgurl:
             response_json['headimgurl'] = headimgurl.replace('\\', '')


### PR DESCRIPTION
    Python 3:
        ISSUE: when it executes `from wechat_sdk import WechatBasic`, it raise an error `cannot import name 'WechatBasic'`, beacause it has no module named 'StringIO' when it executes `from StringIO import StringIO` in file `wechat_sdk/basic.py` in python3
        SOLUTION: add `from io import StringIO` for python3