### PR TITLE
抛出包的 ImportError 对开发者比较友好

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,11 +24,14 @@ wechat-python-sdk 希望能帮你解决微信公众平台开发中的种种不�
 
 请注意：本 SDK 在 pypi.python.org 上的软件包名称为 `wechat-sdk <https://pypi.python.org/pypi/wechat-sdk>`_
 
-可以通过 pip 进行安装
+首先安装依赖::
 
-::
+    $ sudo apt-get install python-dev  # Ubuntu
+    $ sudo pacman -S python-crypto  # ArchLinux
 
-    pip install wechat-sdk
+可以通过 pip 进行安装::
+
+    pip install xmltodict wechat-sdk
 
 也可以通过 easy_install 进行安装
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ wechat-python-sdk 希望能帮你解决微信公众平台开发中的种种不�
 
 首先安装依赖::
 
-    $ sudo apt-get install python-dev  # Ubuntu
+    $ sudo apt-get install python3-crypto  # Ubuntu, or `python-crypto` if you're using python2
     $ sudo pacman -S python-crypto  # ArchLinux
 
 可以通过 pip 进行安装::

--- a/wechat_sdk/__init__.py
+++ b/wechat_sdk/__init__.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
-__all__ = ['WechatConf', 'WechatBasic', 'WechatExt']
+from wechat_sdk.core.conf import WechatConf
+from wechat_sdk.basic import WechatBasic
+from wechat_sdk.ext import WechatExt
 
-try:
-    from wechat_sdk.core.conf import WechatConf
-    from wechat_sdk.basic import WechatBasic
-    from wechat_sdk.ext import WechatExt
-except ImportError:
-    pass
+__all__ = ['WechatConf', 'WechatBasic', 'WechatExt']


### PR DESCRIPTION
安装包的时候，导入总是报

`ImportError: cannot import name 'WechatConf'`

原因是 crypto 依赖 xmltodict。

我认为在导入的时候抛出这个异常对开发者比较友好，要不然找不到无法导入的原因。

另外在README里声明了依赖。
