### PR TITLE
access token expires in 7200s

### DIFF
--- a/wechat_sdk/core/conf.py
+++ b/wechat_sdk/core/conf.py
@@ -150,7 +150,8 @@ class WechatConf(object):
 
         if self.__access_token:
             now = time.time()
-            if self.__access_token_expires_at - now > 60:
+            if (not self.__access_token_expires_at
+                    or self.__access_token_expires_at - now > 7200):
                 return self.__access_token
 
         self.grant_access_token()  # 从腾讯服务器获取 access token 并更新
@@ -166,7 +167,8 @@ class WechatConf(object):
 
         if self.__jsapi_ticket:
             now = time.time()
-            if self.__jsapi_ticket_expires_at - now > 60:
+            if (not self.__jsapi_ticket_expires_at
+                    or self.__jsapi_ticket_expires_at - now > 7200):
                 return self.__jsapi_ticket
 
         self.grant_jsapi_ticket()  # 从腾讯服务器获取 jsapi ticket 并更新


### PR DESCRIPTION
* 根据微信公众号文档，access token 和 jsapi ticket 的过期时间都是两小时。
* 未传 `access_token_expires_at` 时，会出错：
```
  TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'

  File "wechat_sdk/lib/request.py", line 30, in request
    access_token = self.__conf.access_token if self.__conf is not None else access_token
  File "wechat_sdk/core/conf.py", line 153, in access_token
    if self.__access_token_expires_at - now > 60:
```
如果可以认为，开发者传了token但没传过期时间的意思是他自己会维护token的有效性，那这里就应该在有效时间为 `None` 时跳过检查。