### PR TITLE
appoint encoding of `open` to utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@
 # !/usr/bin/env python
 
 from setuptools import setup, find_packages
+from io import open
 
 setup(
     name='wechat-sdk',
     version='0.6.2',
     keywords=('wechat', 'sdk', 'wechat sdk'),
     description=u'微信公众平台Python开发包',
-    long_description=open("README.rst").read(),
+    long_description=open("README.rst", encoding="utf-8").read(),
     license='BSD License',
 
     url='https://github.com/wechat-python-sdk/wechat-python-sdk',
@@ -17,7 +18,7 @@ setup(
 
     packages=find_packages(),
     include_package_data=True,
-    install_requires=list(map(lambda x: x.replace('==', '>=') and x.rstrip('\n'), open("requirements.txt").readlines())),
+    install_requires=list(map(lambda x: x.replace('==', '>=') and x.rstrip('\n'), open("requirements.txt", encoding="utf-8").readlines())),
 
     tests_require=['nose', 'httmock'],
     test_suite='tests',


### PR DESCRIPTION
Python3中的open可以指定encoding，但2不行。于是用io.open，有关io.open见:

https://docs.python.org/2/library/io.html#module-interface